### PR TITLE
Update for numpy/skimage deprecated features + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.pyc
+__pycache__/
+dist/
+build/
+*.egg-info
+*.ipynb_checkpoints

--- a/Notebook_Pyetomo_EELS_3D.ipynb
+++ b/Notebook_Pyetomo_EELS_3D.ipynb
@@ -23,7 +23,7 @@
     "import matplotlib.pyplot as plt\n",
     "from skimage.io import imread\n",
     "from skimage.transform import rotate, radon, iradon, iradon_sart\n",
-    "from skimage.external.tifffile import imsave\n",
+    "from tifffile import imsave\n",
     "\n",
     "from modopt.opt.proximity import SparseThreshold\n",
     "from modopt.opt.cost import costObj\n",
@@ -187,7 +187,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -201,7 +201,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/Notebook_Pyetomo_HAADF_2D.ipynb
+++ b/Notebook_Pyetomo_HAADF_2D.ipynb
@@ -30,7 +30,7 @@
     "import matplotlib.pyplot as plt\n",
     "from skimage.io import imread\n",
     "from skimage.transform import rotate, radon, iradon, iradon_sart\n",
-    "from skimage.external.tifffile import imsave\n",
+    "from tifffile import imsave\n",
     "\n",
     "from modopt.opt.proximity import SparseThreshold\n",
     "from modopt.opt.cost import costObj\n",
@@ -82,8 +82,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fbp = iradon(Sinogram_2D[::1].T, theta=theta_full, circle=True, filter='shepp-logan')\n",
-    "fbp_5 = iradon(Sinogram_2D[::5].T, theta=theta_full[::5], circle=True, filter='shepp-logan')"
+    "fbp = iradon(Sinogram_2D[::1].T, theta=theta_full, circle=True, filter_name='shepp-logan')\n",
+    "fbp_5 = iradon(Sinogram_2D[::5].T, theta=theta_full[::5], circle=True, filter_name='shepp-logan')"
    ]
   },
   {
@@ -118,7 +118,7 @@
     "theta = theta_full [::angular_incr]\n",
     "sinogram = Sinogram_2D[::angular_incr]\n",
     "\n",
-    "fbp_reduced = iradon(sinogram.T, theta=theta_full[::angular_incr], circle=True, filter='shepp-logan')\n",
+    "fbp_reduced = iradon(sinogram.T, theta=theta_full[::angular_incr], circle=True, filter_name='shepp-logan')\n",
     "\n",
     "# Step 1: Define NUFFT sampling:\n",
     "\n",
@@ -252,7 +252,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -266,7 +266,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/pyetomo/gradient.py
+++ b/pyetomo/gradient.py
@@ -25,7 +25,7 @@ class GradAnalysis(GradBasic, PowerMethod):
         GradBasic.__init__(self, data, fourier_op.op, fourier_op.adj_op)
         self.fourier_op = fourier_op
         PowerMethod.__init__(self, self.trans_op_op, self.fourier_op.shape,
-                             data_type=np.complex, auto_run=False)
+                             data_type=complex, auto_run=False)
         self.get_spec_rad(extra_factor=1.1)
 
 
@@ -39,9 +39,9 @@ class GradSynthesis(GradBasic, PowerMethod):
         GradBasic.__init__(self, data, self._op_method, self._trans_op_method)
         self.fourier_op = fourier_op
         self.linear_op = linear_op
-        coef = linear_op.op(np.zeros(fourier_op.shape).astype(np.complex))
+        coef = linear_op.op(np.zeros(fourier_op.shape).astype(complex))
         PowerMethod.__init__(self, self.trans_op_op, coef.shape,
-                             data_type=np.complex, auto_run=False)
+                             data_type=complex, auto_run=False)
         self.get_spec_rad(extra_factor=1.1)
 
     def _op_method(self, data, *args, **kwargs):

--- a/pyetomo/reconstruct.py
+++ b/pyetomo/reconstruct.py
@@ -73,7 +73,7 @@ def sparse_rec_fista(gradient_op, linear_op, prox_op, cost_op,
     start = time.clock()
 
     # Define the initial primal and dual solutions
-    x_init = np.zeros(gradient_op.fourier_op.shape, dtype=np.complex)
+    x_init = np.zeros(gradient_op.fourier_op.shape, dtype=complex)
     alpha = linear_op.op(x_init)
     alpha[...] = 0.0
 
@@ -205,7 +205,7 @@ def sparse_rec_condatvu(gradient_op, linear_op, prox_dual_op, cost_op,
             "Unrecognized std estimation method '{}'.".format(std_est_method))
 
     # Define the initial primal and dual solutions
-    x_init = np.zeros(gradient_op.fourier_op.shape, dtype=np.complex)
+    x_init = np.zeros(gradient_op.fourier_op.shape, dtype=complex)
     weights = linear_op.op(x_init)
 
     # Define the weights used during the thresholding in the dual domain,
@@ -241,7 +241,7 @@ def sparse_rec_condatvu(gradient_op, linear_op, prox_dual_op, cost_op,
     convergence_test = (1.0 / tau - sigma * norm ** 2 >= lipschitz_cst / 2.0)
 
     # Define initial primal and dual solutions
-    primal = np.zeros(gradient_op.fourier_op.shape, dtype=np.complex)
+    primal = np.zeros(gradient_op.fourier_op.shape, dtype=complex)
     dual = linear_op.op(primal)
     dual[...] = 0.0
 

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,5 @@ setup(
     packages=find_packages(),
     platforms="OS Independent",
     package_data=PKGDATA,
-    install_requires=['scipy','numpy','matplotlib','scikit-image','pywavelets','modopt','pynufft'],
+    install_requires=['scipy','numpy','matplotlib','scikit-image','pywavelets','modopt','pynufft','tifffile'],
 )


### PR DESCRIPTION
Includes changes to the library and example notebooks to handle some deprecation changes:

- `np.complex` is deprecated since numpy 1.20 (https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated)
- `skimage.transform.iradon` argument `filter` was changed to `filter_name` in version 0.19 (https://scikit-image.org/docs/stable/api/skimage.transform.html#iradon).

For reference, as of today a fresh install using the `pySAP` conda _environment.yml_ followed by `pyetomo` installs numpy 1.24.1 and skimage 0.19.3.

I tested that the two example notebooks function fully with these changes, but I haven't checked all of the code in detail for further deprecations.

I have also included a basic `.gitignore` to help avoid committing cache/temp/build files.